### PR TITLE
Server shouldn't crash when the client dies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,1 +1,2 @@
 Bit Connor <mutantlemon@gmail.com>
+Takano Akio <aljee@hyper.cx>


### PR DESCRIPTION
When 'hdevtools check' takes a long time, I sometimes find an error in my code myself before hdevtools does, and hit Ctrl-C to interrupt syntastic to fix the error. However the hdevtools server seems to crash if I do this, losing all the cached information. I think the server should keep alive when the client dies while it is processing a command.
