### PR TITLE
Using multiple files with same htdevtools instance

### DIFF
--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -42,7 +42,7 @@ data HDevTools
     | Check
         { socket :: Maybe FilePath
         , ghcOpts :: [String]
-        , file :: String
+        , files :: [String]
         }
     | ModuleFile
         { socket :: Maybe FilePath
@@ -77,7 +77,7 @@ dummyCheck :: HDevTools
 dummyCheck = Check
     { socket = Nothing
     , ghcOpts = []
-    , file = ""
+    , files = []
     }
 
 dummyModuleFile :: HDevTools
@@ -117,8 +117,8 @@ check :: Annotate Ann
 check = record dummyCheck
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION"   += help "ghc options"
-    , file     := def += typFile      += argPos 0 += opt ""
-    ] += help "Check a haskell source file for errors and warnings"
+    , files    := def += typ "FILES..." += args += opt ([] :: [FilePath])
+    ] += help "Check haskell source files for errors and warnings"
 
 moduleFile :: Annotate Ann
 moduleFile = record dummyModuleFile

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -4,7 +4,7 @@ module CommandLoop
     , startCommandLoop
     ) where
 
-import Control.Monad (when)
+import Control.Monad (forM, when)
 import Data.IORef
 import Data.List (find)
 import MonadUtils (MonadIO, liftIO)
@@ -101,10 +101,10 @@ configSession state clientSend ghcOpts = do
     return ()
 
 runCommand :: IORef State -> ClientSend -> Command -> GHC.Ghc ()
-runCommand _ clientSend (CmdCheck file) = do
+runCommand _ clientSend (CmdCheck files) = do
     let noPhase = Nothing
-    target <- GHC.guessTarget file noPhase
-    GHC.setTargets [target]
+    targets <- forM files $ \f -> GHC.guessTarget f noPhase
+    GHC.setTargets targets
     let handler err = GHC.printException err >> return GHC.Failed
     flag <- GHC.handleSourceError handler (GHC.load GHC.LoadAllTargets)
     liftIO $ case flag of

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -46,16 +46,22 @@ doModuleFile sock args =
     serverCommand sock (CmdModuleFile (module_ args)) (ghcOpts args)
 
 doFileCommand :: String -> (HDevTools -> Command) -> FilePath -> HDevTools -> IO ()
-doFileCommand cmdName cmd sock args
-    | null (file args) = do
-        progName <- getProgName
-        hPutStrLn stderr "You must provide a haskell source file. See:"
-        hPutStrLn stderr $ progName ++ " " ++ cmdName ++ " --help"
-    | otherwise = serverCommand sock (cmd args) (ghcOpts args)
+doFileCommand cmdName cmd sock args = do
+  case args of
+    Check { files = [] } -> missingFileError
+    Check {}             -> serverCommand sock (cmd args) (ghcOpts args)
+    -- The other commands take only one file; here the check is against "".
+    _ | null (file args) -> missingFileError
+    _                    -> serverCommand sock (cmd args) (ghcOpts args)
+    where
+        missingFileError = do
+            progName <- getProgName
+            hPutStrLn stderr "You must provide a haskell source file. See:"
+            hPutStrLn stderr $ progName ++ " " ++ cmdName ++ " --help"
 
 doCheck :: FilePath -> HDevTools -> IO ()
 doCheck = doFileCommand "check" $
-    \args -> CmdCheck (file args)
+    \args -> CmdCheck (files args)
 
 doInfo :: FilePath -> HDevTools -> IO ()
 doInfo = doFileCommand "info" $

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -20,7 +20,7 @@ data ClientDirective
     deriving (Read, Show)
 
 data Command
-    = CmdCheck FilePath
+    = CmdCheck [FilePath]
     | CmdModuleFile String
     | CmdInfo FilePath String
     | CmdType FilePath (Int, Int)


### PR DESCRIPTION
I am currently trying:

```
hdevtools check file1.hs
hdevtools check file2.hs
hdevtools check file1.hs
```

and realized that all benefits of hdevtools are lost: Checking `file1.hs` the second time creates a lot of CPU usage, not using any cached results.

Why is that?

It is also interesting that despite losing the hdevtools benefits, hdevtools still uses a lot of RAM: Loading a few hundred files easily eats up 10 GB RAM. So there seems to be some caching going on, but not actually being used.

How am I supposed to use hdevtools with multiple files?
