### PR TITLE
Cabal support

### DIFF
--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -67,6 +67,7 @@ executable hdevtools
                        syb,
                        network,
                        time,
+                       transformers,
                        unix
 
   if impl(ghc == 7.6.*)

--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -72,3 +72,7 @@ executable hdevtools
   if impl(ghc == 7.6.*)
     build-depends:     Cabal == 1.16.*
     cpp-options:       -DENABLE_CABAL
+
+  if impl(ghc == 7.8.*)
+    build-depends:     Cabal == 1.18.*
+    cpp-options:       -DENABLE_CABAL

--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -59,7 +59,6 @@ executable hdevtools
                        Util,
                        Paths_hdevtools
   build-depends:       base == 4.*,
-                       Cabal == 1.16.*,
                        cmdargs,
                        directory,
                        filepath,
@@ -69,3 +68,7 @@ executable hdevtools
                        network,
                        time,
                        unix
+
+  if impl(ghc == 7.6.*)
+    build-depends:     Cabal == 1.16.*
+    cpp-options:       -DENABLE_CABAL

--- a/hdevtools.cabal
+++ b/hdevtools.cabal
@@ -1,5 +1,5 @@
 name:                hdevtools
-version:             0.1.0.5
+version:             0.1.0.6
 synopsis:            Persistent GHC powered background server for FAST haskell development tools
 description:
     'hdevtools' is a backend for text editor plugins, to allow for things such as
@@ -47,7 +47,8 @@ executable hdevtools
   ghc-options:         -Wall
   cpp-options:         -DCABAL
   main-is:             Main.hs
-  other-modules:       Client,
+  other-modules:       Cabal,
+                       Client,
                        CommandArgs,
                        CommandLoop,
                        Daemonize,
@@ -58,8 +59,10 @@ executable hdevtools
                        Util,
                        Paths_hdevtools
   build-depends:       base == 4.*,
+                       Cabal == 1.16.*,
                        cmdargs,
                        directory,
+                       filepath,
                        ghc >= 7.2,
                        ghc-paths,
                        syb,

--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -1,0 +1,102 @@
+module Cabal
+  ( getPackageGhcOpts
+  ) where
+
+import Data.Char (isSpace)
+import Data.List (foldl', nub, isPrefixOf)
+import Data.Monoid (Monoid(..))
+
+import Distribution.PackageDescription (Executable(..), TestSuite(..), Benchmark(..), emptyHookedBuildInfo)
+import Distribution.PackageDescription.Parse (readPackageDescription)
+import Distribution.Simple.Configure (configure)
+import Distribution.Simple.LocalBuildInfo (LocalBuildInfo(..), ComponentLocalBuildInfo(..), Component(..), ComponentName(..), allComponentsBy, componentBuildInfo, foldComponent)
+import Distribution.Simple.Compiler (PackageDB(..))
+import Distribution.Simple.GHC (componentGhcOptions)
+import Distribution.Simple.Program (defaultProgramConfiguration)
+import Distribution.Simple.Program.Db (lookupProgram)
+import Distribution.Simple.Program.Types (ConfiguredProgram(programVersion), simpleProgram)
+import Distribution.Simple.Program.GHC (GhcOptions(..), renderGhcOptions)
+import Distribution.Simple.Setup (ConfigFlags(..), defaultConfigFlags)
+import Distribution.Verbosity (silent)
+import Distribution.Version (Version(..))
+
+import System.Directory (doesFileExist)
+import System.FilePath (takeDirectory, splitFileName, (</>))
+
+componentName :: Component -> ComponentName
+componentName =
+    foldComponent (const CLibName)
+                  (CExeName . exeName)
+                  (CTestName . testName)
+                  (CBenchName . benchmarkName)
+
+getComponentLocalBuildInfo :: LocalBuildInfo -> ComponentName -> ComponentLocalBuildInfo
+getComponentLocalBuildInfo lbi CLibName =
+    case libraryConfig lbi of
+        Nothing -> error $ "internal error: missing library config"
+        Just clbi -> clbi
+getComponentLocalBuildInfo lbi (CExeName name) =
+    case lookup name (executableConfigs lbi) of
+        Nothing -> error $ "internal error: missing config for executable " ++ name
+        Just clbi -> clbi
+getComponentLocalBuildInfo lbi (CTestName name) =
+    case lookup name (testSuiteConfigs lbi) of
+        Nothing -> error $ "internal error: missing config for test suite " ++ name
+        Just clbi -> clbi
+getComponentLocalBuildInfo lbi (CBenchName name) =
+    case lookup name (testSuiteConfigs lbi) of
+        Nothing -> error $ "internal error: missing config for benchmark " ++ name
+        Just clbi -> clbi
+
+
+getPackageGhcOpts :: FilePath -> IO (Either String [String])
+getPackageGhcOpts path = do
+    genPkgDescr <- readPackageDescription silent path
+
+    let cfgFlags' = (defaultConfigFlags defaultProgramConfiguration)
+
+    let sandboxConfig = takeDirectory path </> "cabal.sandbox.config"
+    exists <- doesFileExist sandboxConfig
+
+    cfgFlags <- case exists of
+                     False -> return cfgFlags'
+                     True -> do
+                         sandboxPackageDb <- getSandboxPackageDB sandboxConfig
+                         return $ cfgFlags'
+                                      { configPackageDBs = [Just $ sandboxPackageDb]
+                                      }
+
+    localBuildInfo <- configure (genPkgDescr, emptyHookedBuildInfo) cfgFlags
+    let baseDir = fst . splitFileName $ path
+    case getGhcVersion localBuildInfo of
+        Nothing -> return $ Left "GHC is not configured"
+        Just ghcVersion -> do
+            let ghcOpts' = foldl' mappend mempty $ map (getComponentGhcOptions localBuildInfo) $ flip allComponentsBy (\c -> c) . localPkgDescr $ localBuildInfo
+                -- FIX bug in GhcOptions' `mappend`
+                ghcOpts = ghcOpts' { ghcOptPackageDBs = nub (ghcOptPackageDBs ghcOpts')
+                                   , ghcOptPackages = nub (ghcOptPackages ghcOpts')
+                                   , ghcOptSourcePath = map (baseDir </>) (ghcOptSourcePath ghcOpts')
+                                   }
+            return $ Right $ renderGhcOptions ghcVersion ghcOpts
+
+    where
+    getComponentGhcOptions :: LocalBuildInfo -> Component -> GhcOptions
+    getComponentGhcOptions lbi comp =
+        componentGhcOptions silent lbi bi clbi (buildDir lbi)
+
+      where bi   = componentBuildInfo comp
+            clbi = getComponentLocalBuildInfo lbi (componentName comp)
+
+    getGhcVersion :: LocalBuildInfo -> Maybe Version
+    getGhcVersion lbi = let db = withPrograms lbi
+                         in do ghc <- lookupProgram (simpleProgram "ghc") db
+                               programVersion ghc
+
+    getSandboxPackageDB :: FilePath -> IO PackageDB
+    getSandboxPackageDB sandboxPath = do
+        contents <- readFile sandboxPath
+        return $ SpecificPackageDB $ extractValue . parse $ contents
+      where
+        pkgDbKey = "package-db:"
+        parse = head . filter (pkgDbKey `isPrefixOf`) . lines
+        extractValue = fst . break isSpace . dropWhile isSpace . drop (length pkgDbKey)

--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -89,7 +89,8 @@ getPackageGhcOpts path = do
 
                 let ghcOpts' = foldl' mappend mempty $ map (getComponentGhcOptions localBuildInfo) $ flip allComponentsBy (\c -> c) . localPkgDescr $ localBuildInfo
                     -- FIX bug in GhcOptions' `mappend`
-                    ghcOpts = ghcOpts' { ghcOptPackageDBs = sort $ nub (ghcOptPackageDBs ghcOpts')
+                    ghcOpts = ghcOpts' { ghcOptExtra = filter (/= "-Werror") $ nub $ ghcOptExtra ghcOpts'
+                                       , ghcOptPackageDBs = sort $ nub (ghcOptPackageDBs ghcOpts')
                                        , ghcOptPackages = filter (\(_, pkgId) -> Just (pkgName pkgId) /= mbLibName) $ nub (ghcOptPackages ghcOpts')
                                        , ghcOptSourcePath = map (baseDir </>) (ghcOptSourcePath ghcOpts')
                                        }

--- a/src/Cabal.hs
+++ b/src/Cabal.hs
@@ -1,7 +1,10 @@
+{-# LANGUAGE CPP #-}
 module Cabal
   ( getPackageGhcOpts
   , findCabalFile
   ) where
+
+#ifdef ENABLE_CABAL
 
 import Control.Exception (IOException, catch)
 import Data.Char (isSpace)
@@ -145,3 +148,13 @@ findCabalFile dir = do
     isCabalFile path = cabalExtension `isSuffixOf` path
                     && length path > length cabalExtension
         where cabalExtension = ".cabal"
+
+# else
+
+getPackageGhcOpts :: FilePath -> IO (Either String [String])
+getPackageGhcOpts _ = return $ Right []
+
+findCabalFile :: FilePath -> IO (Maybe FilePath)
+findCabalFile _ = return Nothing
+
+#endif

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -53,22 +53,26 @@ data HDevTools
     | Check
         { socket :: Maybe FilePath
         , ghcOpts :: [String]
+        , cabalOpts :: [String]
         , file :: String
         }
     | ModuleFile
         { socket :: Maybe FilePath
         , ghcOpts :: [String]
+        , cabalOpts :: [String]
         , module_ :: String
         }
     | Info
         { socket :: Maybe FilePath
         , ghcOpts :: [String]
+        , cabalOpts :: [String]
         , file :: String
         , identifier :: String
         }
     | Type
         { socket :: Maybe FilePath
         , ghcOpts :: [String]
+        , cabalOpts :: [String]
         , file :: String
         , line :: Int
         , col :: Int
@@ -88,6 +92,7 @@ dummyCheck :: HDevTools
 dummyCheck = Check
     { socket = Nothing
     , ghcOpts = []
+    , cabalOpts = []
     , file = ""
     }
 
@@ -95,6 +100,7 @@ dummyModuleFile :: HDevTools
 dummyModuleFile = ModuleFile
     { socket = Nothing
     , ghcOpts = []
+    , cabalOpts = []
     , module_ = ""
     }
 
@@ -102,6 +108,7 @@ dummyInfo :: HDevTools
 dummyInfo = Info
     { socket = Nothing
     , ghcOpts = []
+    , cabalOpts = []
     , file = ""
     , identifier = ""
     }
@@ -110,6 +117,7 @@ dummyType :: HDevTools
 dummyType = Type
     { socket = Nothing
     , ghcOpts = []
+    , cabalOpts = []
     , file = ""
     , line = 0
     , col = 0
@@ -128,6 +136,11 @@ check :: Annotate Ann
 check = record dummyCheck
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION"   += help "ghc options"
+#ifdef ENABLE_CABAL
+    , cabalOpts := def += typ "OPTION"  += help "cabal options"
+#else
+    , cabalOpts := def += ignore
+#endif
     , file     := def += typFile      += argPos 0 += opt ""
     ] += help "Check a haskell source file for errors and warnings"
 
@@ -135,6 +148,11 @@ moduleFile :: Annotate Ann
 moduleFile = record dummyModuleFile
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
+#ifdef ENABLE_CABAL
+    , cabalOpts := def += typ "OPTION"  += help "cabal options"
+#else
+    , cabalOpts := def += ignore
+#endif
     , module_  := def += typ "MODULE" += argPos 0
     ] += help "Get the haskell source file corresponding to a module name"
 
@@ -142,6 +160,11 @@ info :: Annotate Ann
 info = record dummyInfo
     [ socket     := def += typFile += help "socket file to use"
     , ghcOpts    := def += typ "OPTION" += help "ghc options"
+#ifdef ENABLE_CABAL
+    , cabalOpts := def += typ "OPTION"  += help "cabal options"
+#else
+    , cabalOpts := def += ignore
+#endif
     , file       := def += typFile      += argPos 0 += opt ""
     , identifier := def += typ "IDENTIFIER" += argPos 1
     ] += help "Get info from GHC about the specified identifier"
@@ -150,6 +173,11 @@ type_ :: Annotate Ann
 type_ = record dummyType
     [ socket   := def += typFile += help "socket file to use"
     , ghcOpts  := def += typ "OPTION" += help "ghc options"
+#ifdef ENABLE_CABAL
+    , cabalOpts := def += typ "OPTION"  += help "cabal options"
+#else
+    , cabalOpts := def += ignore
+#endif
     , file     := def += typFile      += argPos 0 += opt ""
     , line     := def += typ "LINE"   += argPos 1
     , col      := def += typ "COLUMN" += argPos 2

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -26,7 +26,7 @@ programVersion =
 
 cabalVersion :: String
 cabalVersion =
-#ifdef CABAL
+#ifdef ENABLE_CABAL
     "cabal-" ++ VERSION_Cabal
 #else
     "no cabal support"

--- a/src/CommandArgs.hs
+++ b/src/CommandArgs.hs
@@ -24,11 +24,22 @@ programVersion =
     "unknown-version (not built with cabal)"
 #endif
 
+cabalVersion :: String
+cabalVersion =
+#ifdef CABAL
+    "cabal-" ++ VERSION_Cabal
+#else
+    "no cabal support"
+#endif
+
 fullVersion :: String
 fullVersion =
     concat
         [ programVersion
-        , " (ghc-", Config.cProjectVersion, "-", arch, "-", os, ")"
+        , " ("
+        , "ghc-", Config.cProjectVersion, "-", arch, "-", os
+        , ", ", cabalVersion
+        , ")"
         ]
 
 data HDevTools

--- a/src/CommandLoop.hs
+++ b/src/CommandLoop.hs
@@ -1,12 +1,15 @@
 {-# LANGUAGE CPP #-}
 module CommandLoop
     ( newCommandLoopState
+    , Config(..)
+    , CabalConfig(..)
+    , newConfig
     , startCommandLoop
     ) where
 
 import Control.Monad (when)
 import Data.IORef
-import Data.List (find)
+import Data.List (find, isSuffixOf)
 import MonadUtils (MonadIO, liftIO)
 import System.Exit (ExitCode(ExitFailure, ExitSuccess))
 import qualified ErrUtils
@@ -14,11 +17,14 @@ import qualified Exception (ExceptionMonad)
 import qualified GHC
 import qualified GHC.Paths
 import qualified Outputable
+import System.Directory (getCurrentDirectory, getDirectoryContents)
+import System.FilePath ((</>))
+import System.Posix.Types (EpochTime)
+import System.Posix.Files (getFileStatus, modificationTime)
 
 import Types (ClientDirective(..), Command(..))
 import Info (getIdentifierInfo, getType)
-
-type CommandObj = (Command, [String])
+import Cabal (getPackageGhcOpts)
 
 type ClientSend = ClientDirective -> IO ()
 
@@ -32,6 +38,36 @@ newCommandLoopState = do
         { stateWarningsEnabled = True
         }
 
+data CabalConfig = CabalConfig
+    { cabalConfigPath :: FilePath
+    , cabalConfigLastUpdatedAt :: EpochTime
+    }
+    deriving Eq
+
+mkCabalConfig :: FilePath -> IO CabalConfig
+mkCabalConfig path = do
+    fileStatus <- getFileStatus path
+    return $ CabalConfig { cabalConfigPath = path
+                         , cabalConfigLastUpdatedAt = modificationTime fileStatus
+                         }
+
+data Config = Config
+    { configGhcOpts :: [String]
+    , configCabal :: Maybe CabalConfig
+    }
+    deriving Eq
+
+newConfig :: [String] -> IO Config
+newConfig ghcOpts = do
+    mbCabalFile <- findCabalFile
+    mbCabalConfig <- maybe (return Nothing) (fmap Just . mkCabalConfig) mbCabalFile
+    return $ Config { configGhcOpts = ghcOpts
+                    , configCabal = mbCabalConfig
+                    }
+
+
+type CommandObj = (Command, Config)
+
 withWarnings :: (MonadIO m, Exception.ExceptionMonad m) => IORef State -> Bool -> m a -> m a
 withWarnings state warningsValue action = do
     beforeState <- liftIO $ getWarnings
@@ -44,22 +80,26 @@ withWarnings state warningsValue action = do
     setWarnings :: Bool -> IO ()
     setWarnings val = modifyIORef state $ \s -> s { stateWarningsEnabled = val }
 
-startCommandLoop :: IORef State -> ClientSend -> IO (Maybe CommandObj) -> [String] -> Maybe Command -> IO ()
-startCommandLoop state clientSend getNextCommand initialGhcOpts mbInitial = do
+startCommandLoop :: IORef State -> ClientSend -> IO (Maybe CommandObj) -> Config -> Maybe Command -> IO ()
+startCommandLoop state clientSend getNextCommand initialConfig mbInitialCommand = do
     continue <- GHC.runGhc (Just GHC.Paths.libdir) $ do
-        configOk <- GHC.gcatch (configSession state clientSend initialGhcOpts >> return True)
-            handleConfigError
-        if configOk
-            then do
-                doMaybe mbInitial $ \cmd -> sendErrors (runCommand state clientSend cmd)
-                processNextCommand False
-            else processNextCommand True
+        configResult <- configSession state clientSend initialConfig
+        case configResult of
+          Left e -> do
+              liftIO $ mapM_ clientSend
+                  [ ClientStderr e
+                  , ClientExit (ExitFailure 1)
+                  ]
+              processNextCommand True
+          Right _ -> do
+              doMaybe mbInitialCommand $ \cmd -> sendErrors (runCommand state clientSend cmd)
+              processNextCommand False
 
     case continue of
         Nothing ->
             -- Exit
             return ()
-        Just (cmd, ghcOpts) -> startCommandLoop state clientSend getNextCommand ghcOpts (Just cmd)
+        Just (cmd, config) -> startCommandLoop state clientSend getNextCommand config (Just cmd)
     where
     processNextCommand :: Bool -> GHC.Ghc (Maybe CommandObj)
     processNextCommand forceReconfig = do
@@ -68,37 +108,53 @@ startCommandLoop state clientSend getNextCommand initialGhcOpts mbInitial = do
             Nothing ->
                 -- Exit
                 return Nothing
-            Just (cmd, ghcOpts) ->
-                if forceReconfig || (ghcOpts /= initialGhcOpts)
-                    then return (Just (cmd, ghcOpts))
+            Just (cmd, config) ->
+                if forceReconfig || (config /= initialConfig)
+                    then return (Just (cmd, config))
                     else sendErrors (runCommand state clientSend cmd) >> processNextCommand False
 
     sendErrors :: GHC.Ghc () -> GHC.Ghc ()
-    sendErrors action = GHC.gcatch action (\x -> handleConfigError x >> return ())
-
-    handleConfigError :: GHC.GhcException -> GHC.Ghc Bool
-    handleConfigError e = do
+    sendErrors action = GHC.gcatch action $ \e -> do
         liftIO $ mapM_ clientSend
-            [ ClientStderr (GHC.showGhcException e "")
+            [ ClientStderr $ GHC.showGhcException e ""
             , ClientExit (ExitFailure 1)
             ]
-        return False
+        return ()
 
 doMaybe :: Monad m => Maybe a -> (a -> m ()) -> m ()
 doMaybe Nothing _ = return ()
 doMaybe (Just x) f = f x
 
-configSession :: IORef State -> ClientSend -> [String] -> GHC.Ghc ()
-configSession state clientSend ghcOpts = do
-    initialDynFlags <- GHC.getSessionDynFlags
-    let updatedDynFlags = initialDynFlags
-            { GHC.log_action = logAction state clientSend
-            , GHC.ghcLink = GHC.NoLink
-            , GHC.hscTarget = GHC.HscInterpreted
-            }
-    (finalDynFlags, _, _) <- GHC.parseDynamicFlags updatedDynFlags (map GHC.noLoc ghcOpts)
-    _ <- GHC.setSessionDynFlags finalDynFlags
-    return ()
+configSession :: IORef State -> ClientSend -> Config -> GHC.Ghc (Either String ())
+configSession state clientSend config = do
+    eCabalGhcOpts <- case configCabal config of
+                      Nothing ->
+                          return $ Right []
+                      Just cabalConfig -> do
+                          liftIO $ getPackageGhcOpts $ cabalConfigPath cabalConfig
+
+    case eCabalGhcOpts of
+      Left e -> return $ Left e
+      Right cabalGhcOpts -> do
+          let allGhcOpts = cabalGhcOpts ++ (configGhcOpts config)
+          GHC.gcatch (fmap Right $ updateDynFlags allGhcOpts)
+                     (fmap Left . handleGhcError)
+  where
+    updateDynFlags :: [String] -> GHC.Ghc ()
+    updateDynFlags ghcOpts = do
+        initialDynFlags <- GHC.getSessionDynFlags
+        let updatedDynFlags = initialDynFlags
+                { GHC.log_action = logAction state clientSend
+                , GHC.ghcLink = GHC.NoLink
+                , GHC.hscTarget = GHC.HscInterpreted
+                }
+        (finalDynFlags, _, _) <- GHC.parseDynamicFlags updatedDynFlags (map GHC.noLoc ghcOpts)
+        _ <- GHC.setSessionDynFlags finalDynFlags
+        return ()
+
+    handleGhcError :: GHC.GhcException -> GHC.Ghc String
+    handleGhcError e = return $ GHC.showGhcException e ""
+
 
 runCommand :: IORef State -> ClientSend -> Command -> GHC.Ghc ()
 runCommand _ clientSend (CmdCheck file) = do
@@ -194,3 +250,15 @@ logActionSend state clientSend severity out = do
     isWarning :: GHC.Severity -> Bool
     isWarning GHC.SevWarning = True
     isWarning _ = False
+
+findCabalFile :: IO (Maybe FilePath)
+findCabalFile = do
+    curDir <- getCurrentDirectory
+    allFiles <- getDirectoryContents curDir
+    return $ fmap (curDir </>) $ find (isCabalFile) allFiles
+
+    where
+    isCabalFile :: FilePath -> Bool
+    isCabalFile path = cabalExtension `isSuffixOf` path
+                    && length path > length cabalExtension
+        where cabalExtension = ".cabal"

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -40,6 +40,7 @@ main = do
     let extra = emptyCommandExtra
                     { ceGhcOptions = ghcOpts args
                     , ceCabalConfig = mCabalFile
+                    , ceCabalOptions = cabalOpts args
                     }
 
     let defaultSocketPath = maybe "" takeDirectory mCabalFile </> defaultSocketFile

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,5 +1,7 @@
 module Main where
 
+import Data.Maybe (fromMaybe)
+import Data.Traversable (Traversable(..))
 import System.Directory (getCurrentDirectory)
 import System.Environment (getProgName)
 import System.IO (hPutStrLn, stderr)
@@ -10,7 +12,7 @@ import Client (getServerStatus, serverCommand, stopServer)
 import CommandArgs
 import Daemonize (daemonize)
 import Server (startServer, createListenSocket)
-import Types (Command(..))
+import Types (Command(..), CommandExtra(..), emptyCommandExtra)
 
 absoluteFilePath :: FilePath -> IO FilePath
 absoluteFilePath path = if isAbsolute path then return path else do
@@ -18,15 +20,8 @@ absoluteFilePath path = if isAbsolute path then return path else do
     return $ dir </> path
 
 
-defaultSocketPathForDir :: FilePath -> IO FilePath
-defaultSocketPathForDir dir = do
-    mbCabalFile <- findCabalFile dir
-    case mbCabalFile of
-        Nothing -> return socketFile
-        Just cabalFile -> return $ takeDirectory cabalFile </> socketFile
-
-  where socketFile :: FilePath
-        socketFile = ".hdevtools.sock"
+defaultSocketFile :: FilePath
+defaultSocketFile = ".hdevtools.sock"
 
 
 fileArg :: HDevTools -> Maybe String
@@ -41,16 +36,24 @@ main :: IO ()
 main = do
     args <- loadHDevTools
     dir  <- maybe getCurrentDirectory (return . takeDirectory) $ fileArg args
-    sock <- maybe (defaultSocketPathForDir dir) return (socket args)
-    case args of
-        Admin {} -> doAdmin sock args
-        Check {} -> doCheck sock args
-        ModuleFile {} -> doModuleFile sock args
-        Info {} -> doInfo sock args
-        Type {} -> doType sock args
+    mCabalFile <- findCabalFile dir >>= traverse absoluteFilePath
+    let extra = emptyCommandExtra
+                    { ceGhcOptions = ghcOpts args
+                    , ceCabalConfig = mCabalFile
+                    }
 
-doAdmin :: FilePath -> HDevTools -> IO ()
-doAdmin sock args
+    let defaultSocketPath = maybe "" takeDirectory mCabalFile </> defaultSocketFile
+    let sock = fromMaybe defaultSocketPath $ socket args
+
+    case args of
+        Admin {} -> doAdmin sock args extra
+        Check {} -> doCheck sock args extra
+        ModuleFile {} -> doModuleFile sock args extra
+        Info {} -> doInfo sock args extra
+        Type {} -> doType sock args extra
+
+doAdmin :: FilePath -> HDevTools -> CommandExtra -> IO ()
+doAdmin sock args _extra
     | start_server args =
         if noDaemon args then startServer sock Nothing
             else do
@@ -63,12 +66,12 @@ doAdmin sock args
         hPutStrLn stderr "You must provide a command. See:"
         hPutStrLn stderr $ progName ++ " --help"
 
-doModuleFile :: FilePath -> HDevTools -> IO ()
-doModuleFile sock args =
-    serverCommand sock (CmdModuleFile (module_ args)) (ghcOpts args)
+doModuleFile :: FilePath -> HDevTools -> CommandExtra -> IO ()
+doModuleFile sock args extra =
+    serverCommand sock (CmdModuleFile (module_ args)) extra
 
-doFileCommand :: String -> (HDevTools -> Command) -> FilePath -> HDevTools -> IO ()
-doFileCommand cmdName cmd sock args
+doFileCommand :: String -> (HDevTools -> Command) -> FilePath -> HDevTools -> CommandExtra -> IO ()
+doFileCommand cmdName cmd sock args extra
     | null (file args) = do
         progName <- getProgName
         hPutStrLn stderr "You must provide a haskell source file. See:"
@@ -76,16 +79,16 @@ doFileCommand cmdName cmd sock args
     | otherwise = do
         absFile <- absoluteFilePath $ file args
         let args' = args { file = absFile }
-        serverCommand sock (cmd args') (ghcOpts args')
+        serverCommand sock (cmd args') extra
 
-doCheck :: FilePath -> HDevTools -> IO ()
+doCheck :: FilePath -> HDevTools -> CommandExtra -> IO ()
 doCheck = doFileCommand "check" $
     \args -> CmdCheck (file args)
 
-doInfo :: FilePath -> HDevTools -> IO ()
+doInfo :: FilePath -> HDevTools -> CommandExtra -> IO ()
 doInfo = doFileCommand "info" $
     \args -> CmdInfo (file args) (identifier args)
 
-doType :: FilePath -> HDevTools -> IO ()
+doType :: FilePath -> HDevTools -> CommandExtra -> IO ()
 doType = doFileCommand "type" $
     \args -> CmdType (file args) (line args, col args)

--- a/src/Server.hs
+++ b/src/Server.hs
@@ -49,7 +49,7 @@ clientSend currentClient clientDirective = do
         Just h -> ignoreEPipe $ do
             hPutStrLn h (show clientDirective)
             hFlush h
-        Nothing -> error "This is impossible"
+        Nothing -> return ()
     where
     -- EPIPE means that the client is no longer there.
     ignoreEPipe = handleJust (guard . isEPipe) (const $ return ())

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -2,12 +2,24 @@ module Types
     ( ServerDirective(..)
     , ClientDirective(..)
     , Command(..)
+    , CommandExtra(..)
+    , emptyCommandExtra
     ) where
 
 import System.Exit (ExitCode)
 
+data CommandExtra = CommandExtra
+  { ceGhcOptions :: [String]
+  , ceCabalConfig :: Maybe FilePath
+  } deriving (Read, Show)
+
+emptyCommandExtra :: CommandExtra
+emptyCommandExtra = CommandExtra { ceGhcOptions = []
+                                 , ceCabalConfig = Nothing
+                                 }
+
 data ServerDirective
-    = SrvCommand Command [String]
+    = SrvCommand Command CommandExtra
     | SrvStatus
     | SrvExit
     deriving (Read, Show)

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -11,11 +11,13 @@ import System.Exit (ExitCode)
 data CommandExtra = CommandExtra
   { ceGhcOptions :: [String]
   , ceCabalConfig :: Maybe FilePath
+  , ceCabalOptions :: [String]
   } deriving (Read, Show)
 
 emptyCommandExtra :: CommandExtra
 emptyCommandExtra = CommandExtra { ceGhcOptions = []
                                  , ceCabalConfig = Nothing
+                                 , ceCabalOptions = []
                                  }
 
 data ServerDirective


### PR DESCRIPTION
This patch adds support of Cabal packages.

Hdevtools currently doesn't know anything about Cabal system: it can't find out source code directories, package database locations, list of packages or Haskell language extensions to use.

This patch adds support of extracting GHC options based on Cabal package description, support for Cabal sandboxes.
