### PR TITLE
add CWD in server status output

### DIFF
--- a/src/Server.hs
+++ b/src/Server.hs
@@ -5,7 +5,7 @@ import Control.Monad (guard)
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import GHC.IO.Exception (IOErrorType(ResourceVanished))
 import Network (PortID(UnixSocket), Socket, accept, listenOn, sClose)
-import System.Directory (removeFile)
+import System.Directory (removeFile, getCurrentDirectory)
 import System.Exit (ExitCode(ExitSuccess))
 import System.IO (Handle, hClose, hFlush, hGetLine, hPutStrLn)
 import System.IO.Error (ioeGetErrorType, isDoesNotExistError)
@@ -72,8 +72,10 @@ getNextCommand currentClient sock = do
         Just (SrvCommand cmd ghcOpts) -> do
             return $ Just (cmd, ghcOpts)
         Just SrvStatus -> do
+            cwd <- getCurrentDirectory
             mapM_ (clientSend currentClient) $
                 [ ClientStdout "Server is running."
+                , ClientStdout ("Server CWD is " ++ cwd)
                 , ClientExit ExitSuccess
                 ]
             getNextCommand currentClient sock


### PR DESCRIPTION
Forwarding mvoidex#1 to the upstream.

---

README mentions that filenames are resolved relative to the server's CWD (current working directory) — rather than to the client's.

While it's technically possible to intrusively determine working path of a foreign process (with tools like `readlink /proc/$PID/cwd`, or `procexp.exe` on Windows) — these methods are rarely userfriendly and mostly inconvenient for regular use (though excellent for troubleshooting/debug).

This addition can be very useful to simplify hdevtools setup and plugin integration, especially on Windows.
